### PR TITLE
bug fix: switch username and email

### DIFF
--- a/app/src/main/java/com/example/partymaker/ui/auth/LoginActivity.java
+++ b/app/src/main/java/com/example/partymaker/ui/auth/LoginActivity.java
@@ -147,7 +147,7 @@ public class LoginActivity extends AppCompatActivity {
                         if (createTask.isSuccessful()) {
                             Log.d("LoginActivity", "Test user created successfully");
                             // Create user in database
-                            User testUser = new User(testEmail, "Test User");
+                            User testUser = new User("Test User", testEmail);
                             DBRef.refUsers.child(testEmail.replace('.', ' ')).setValue(testUser);
                         } else {
                             Log.d("LoginActivity", "Test user creation failed: " + 
@@ -316,7 +316,7 @@ public class LoginActivity extends AppCompatActivity {
                   String email = firebaseUser.getEmail();
                   String username = firebaseUser.getDisplayName();
 
-                  User u = new User(email, username);
+                  User u = new User(username, email);
 
                   // Replace dots with spaces in the email to make it a valid key in Firebase
                   assert email != null;

--- a/app/src/main/java/com/example/partymaker/ui/auth/RegisterActivity.java
+++ b/app/src/main/java/com/example/partymaker/ui/auth/RegisterActivity.java
@@ -133,7 +133,7 @@ public class RegisterActivity extends AppCompatActivity {
             if (task.isSuccessful()) {
                 Log.d("RegisterActivity", "Test user created successfully");
                 // Create user in database
-                User testUser = new User(testEmail, "Test User");
+                User testUser = new User("Test User", testEmail);
                 DBRef.refUsers.child(testEmail.replace('.', ' ')).setValue(testUser);
             } else {
                 // User might already exist, that's fine
@@ -642,7 +642,7 @@ public class RegisterActivity extends AppCompatActivity {
                 sendSuccessNotification(username);
 
                 // Save user data to database
-                User user = new User(email, username);
+                User user = new User(username, email);
                 DBRef.refUsers.child(email.replace('.', ' ')).setValue(user);
 
                 // Navigate to login screen after celebration


### PR DESCRIPTION
When I tried to Edit Profile and save a new username, I would get Invalid user key, so I went to firebase realtime database, and saw that all the created accounts had switched email and username, after investigating I saw that the new User are switching between username and email, I switched and validated its fixed:

First account is before the change and second is after
<img width="418" height="254" alt="image" src="https://github.com/user-attachments/assets/140b42cd-19a3-400d-b13e-f66baf9065d7" />

**Important note**: This did not fix the "Invalid User Key" problem, I still cannot change the username in profile, I will keep investigating, Natanel if you have an idea of why is this happening let me know (I believe it might be something between server and client)